### PR TITLE
fix(api): correct Swagger response documentation

### DIFF
--- a/apps/api/src/v1/health/health.controller.ts
+++ b/apps/api/src/v1/health/health.controller.ts
@@ -1,6 +1,33 @@
 import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiProperty, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ApiResponseDto } from '../../common/dto/api-response.dto';
+
+class HealthData {
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty()
+  uptime: number;
+}
+
+class HealthMetaDto {
+  @ApiProperty()
+  timestamp: string;
+
+  @ApiProperty()
+  version: string;
+}
+
+class HealthResponseDto {
+  @ApiProperty({ default: true })
+  success: boolean;
+
+  @ApiProperty({ type: HealthData })
+  data: HealthData;
+
+  @ApiProperty({ type: HealthMetaDto })
+  meta: HealthMetaDto;
+}
 
 @ApiTags('health')
 @Controller('v1/health')
@@ -10,9 +37,10 @@ export class HealthController {
   @ApiResponse({
     status: 200,
     description: 'Service is healthy',
+    type: HealthResponseDto,
   })
   @HttpCode(HttpStatus.OK)
-  check(): ApiResponseDto<{ status: string; uptime: number }> {
+  check(): ApiResponseDto<HealthData> {
     return {
       success: true,
       data: {

--- a/apps/api/src/v1/items/dto/item.dto.ts
+++ b/apps/api/src/v1/items/dto/item.dto.ts
@@ -27,6 +27,98 @@ export class ItemDto {
   attributes: ItemAttributesDto;
 }
 
+// Specific response DTOs for Swagger documentation
+export class ItemMetaDto {
+  @ApiProperty()
+  timestamp: string;
+
+  @ApiProperty()
+  version: string;
+
+  @ApiProperty({ required: false })
+  requestId?: string;
+}
+
+export class PaginationMetaDto {
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  totalPages: number;
+
+  @ApiProperty()
+  hasNext: boolean;
+
+  @ApiProperty()
+  hasPrev: boolean;
+}
+
+export class PaginationLinksDto {
+  @ApiProperty()
+  self: string;
+
+  @ApiProperty()
+  first: string;
+
+  @ApiProperty()
+  last: string;
+
+  @ApiProperty({ nullable: true })
+  next: string | null;
+
+  @ApiProperty({ nullable: true })
+  prev: string | null;
+}
+
+export class ItemResponseDto {
+  @ApiProperty({ default: true })
+  success: boolean;
+
+  @ApiProperty({ type: ItemDto })
+  data: ItemDto;
+
+  @ApiProperty({ type: ItemMetaDto })
+  meta: ItemMetaDto;
+}
+
+export class ItemsListResponseDto {
+  @ApiProperty({ default: true })
+  success: boolean;
+
+  @ApiProperty({ type: [ItemDto] })
+  data: ItemDto[];
+
+  @ApiProperty({
+    type: 'object',
+    properties: {
+      timestamp: { type: 'string' },
+      version: { type: 'string' },
+      requestId: { type: 'string' },
+      pagination: {
+        type: 'object',
+        properties: {
+          page: { type: 'number' },
+          limit: { type: 'number' },
+          total: { type: 'number' },
+          totalPages: { type: 'number' },
+          hasNext: { type: 'boolean' },
+          hasPrev: { type: 'boolean' },
+        },
+      },
+    },
+  })
+  meta: ItemMetaDto & { pagination: PaginationMetaDto };
+
+  @ApiProperty({ type: PaginationLinksDto })
+  links: PaginationLinksDto;
+}
+
 export class CreateItemAttributesDto {
   @ApiProperty({ description: 'Item name', minLength: 1 })
   @IsString()

--- a/apps/api/src/v1/items/items.controller.ts
+++ b/apps/api/src/v1/items/items.controller.ts
@@ -12,13 +12,20 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import {
+  ApiErrorResponseDto,
   ApiResponseDto,
   PaginatedApiResponseDto,
   PaginationLinksDto,
   PaginationMetaDto,
 } from '../../common/dto/api-response.dto';
 import { PaginationQueryDto } from '../../common/dto/pagination.dto';
-import { CreateItemDto, ItemDto, UpdateItemDto } from './dto/item.dto';
+import {
+  CreateItemDto,
+  ItemDto,
+  ItemResponseDto,
+  ItemsListResponseDto,
+  UpdateItemDto,
+} from './dto/item.dto';
 import { ItemsService } from './items.service';
 
 @ApiTags('items')
@@ -31,7 +38,12 @@ export class ItemsController {
   @ApiResponse({
     status: 201,
     description: 'Item created successfully',
-    type: ItemDto,
+    type: ItemResponseDto,
+  })
+  @ApiResponse({
+    status: 422,
+    description: 'Validation error',
+    type: ApiErrorResponseDto,
   })
   @HttpCode(HttpStatus.CREATED)
   create(@Body() createItemDto: CreateItemDto): ApiResponseDto<ItemDto> {
@@ -54,7 +66,7 @@ export class ItemsController {
   @ApiResponse({
     status: 200,
     description: 'Items retrieved successfully',
-    type: [ItemDto],
+    type: ItemsListResponseDto,
   })
   findAll(@Query() query: PaginationQueryDto): PaginatedApiResponseDto<ItemDto> {
     const { items, total } = this.itemsService.findAll(query);
@@ -110,11 +122,12 @@ export class ItemsController {
   @ApiResponse({
     status: 200,
     description: 'Item retrieved successfully',
-    type: ItemDto,
+    type: ItemResponseDto,
   })
   @ApiResponse({
     status: 404,
     description: 'Item not found',
+    type: ApiErrorResponseDto,
   })
   findOne(@Param('id') id: string): ApiResponseDto<ItemDto> {
     const item = this.itemsService.findOne(id);
@@ -134,11 +147,17 @@ export class ItemsController {
   @ApiResponse({
     status: 200,
     description: 'Item updated successfully',
-    type: ItemDto,
+    type: ItemResponseDto,
   })
   @ApiResponse({
     status: 404,
     description: 'Item not found',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 422,
+    description: 'Validation error',
+    type: ApiErrorResponseDto,
   })
   update(@Param('id') id: string, @Body() updateItemDto: UpdateItemDto): ApiResponseDto<ItemDto> {
     // Extract data from the DTO structure
@@ -164,6 +183,7 @@ export class ItemsController {
   @ApiResponse({
     status: 404,
     description: 'Item not found',
+    type: ApiErrorResponseDto,
   })
   @HttpCode(HttpStatus.NO_CONTENT)
   remove(@Param('id') id: string): void {


### PR DESCRIPTION
Update @ApiResponse decorators to use specific response DTOs instead of generic types, ensuring API documentation shows actual ItemDto structures rather than generic placeholders.

## Checklist

- [X] Tests pass locally
- [X] Ready for review

## Related Issues

<!-- Link related issues: "Closes #123" or "Fixes #456" -->